### PR TITLE
Replace back-ref spacing with non-breaking space

### DIFF
--- a/src/Renderer/FootnoteRenderer.php
+++ b/src/Renderer/FootnoteRenderer.php
@@ -7,7 +7,7 @@ use League\CommonMark\Block\Element\AbstractBlock;
 use League\CommonMark\Block\Renderer\BlockRendererInterface;
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\HtmlElement;
-use League\CommonMark\Inline\Element\Text;
+use League\CommonMark\Inline\Element\HtmlInline;
 use RZ\CommonMark\Ext\Footnote\Footnote;
 use RZ\CommonMark\Ext\Footnote\FootnoteBackref;
 
@@ -31,7 +31,7 @@ final class FootnoteRenderer implements BlockRendererInterface
         ]);
 
         foreach ($block->getBackrefs() as $backref) {
-            $block->lastChild()->appendChild(new Text(' '));
+            $block->lastChild()->appendChild(new HtmlInline('&#160;'));
             $block->lastChild()->appendChild($backref);
         }
 

--- a/src/Renderer/FootnoteRenderer.php
+++ b/src/Renderer/FootnoteRenderer.php
@@ -31,7 +31,7 @@ final class FootnoteRenderer implements BlockRendererInterface
         ]);
 
         foreach ($block->getBackrefs() as $backref) {
-            $block->lastChild()->appendChild(new HtmlInline('&#160;'));
+            $block->lastChild()->appendChild(new HtmlInline('&nbsp;'));
             $block->lastChild()->appendChild($backref);
         }
 

--- a/tests/Functional/data/anonymous.html
+++ b/tests/Functional/data/anonymous.html
@@ -2,4 +2,4 @@
 Nullam quis risus eget urna mollis<a class="footnote-ref" id="fn-ref-this-is-an-anonymous" href="#fn-this-is-an-anonymous"><sup>1</sup></a> ornare vel eu leo. Donec id elit non mi
 porta gravida at eget metus. Duis mollis, est non commodo luctus, nisi erat porttitor
 ligula, eget lacinia odio sem nec elit.</p>
-<div class="footnotes"><hr /><ol><li class="footnote" id="fn-this-is-an-anonymous"><p>This is an anonymous footnote <a class="footnote-backref" rev="footnote" href="#fn-ref-this-is-an-anonymous">&#8617;</a></p></li></ol></div>
+<div class="footnotes"><hr /><ol><li class="footnote" id="fn-this-is-an-anonymous"><p>This is an anonymous footnote&nbsp;<a class="footnote-backref" rev="footnote" href="#fn-ref-this-is-an-anonymous">&#8617;</a></p></li></ol></div>

--- a/tests/Functional/data/duplicated.html
+++ b/tests/Functional/data/duplicated.html
@@ -8,8 +8,8 @@ nisi erat porttitor ligula, eget lacinia odio<a class="footnote-ref" id="fn-ref-
 Cras mattis consectetur purus sit amet fermentum. Fusce dapibus<a class="footnote-ref" id="fn-ref-ref__2" href="#fn-ref"><sup>1</sup></a>, tellus ac cursus
 commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
 Integer posuere<a class="footnote-ref" id="fn-ref-ref4" href="#fn-ref4"><sup>4</sup></a> erat a ante venenatis dapibus posuere velit aliquet<a class="footnote-ref" id="fn-ref-ref3__2" href="#fn-ref3"><sup>3</sup></a>.</p>
-<div class="footnotes"><hr /><ol><li class="footnote" id="fn-ref"><p>Risus Euismod Pharetra <a class="footnote-backref" rev="footnote" href="#fn-ref-ref">&#8617;</a> <a class="footnote-backref" rev="footnote" href="#fn-ref-ref__2">&#8617;</a></p></li>
+<div class="footnotes"><hr /><ol><li class="footnote" id="fn-ref"><p>Risus Euismod Pharetra&nbsp;<a class="footnote-backref" rev="footnote" href="#fn-ref-ref">&#8617;</a>&nbsp;<a class="footnote-backref" rev="footnote" href="#fn-ref-ref__2">&#8617;</a></p></li>
 <li class="footnote" id="fn-ref2"><p>Etiam porta sem malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl
-consectetur et. Maecenas faucibus mollis interdum. Maecenas faucibus mollis interdum. <a class="footnote-backref" rev="footnote" href="#fn-ref-ref2">&#8617;</a></p></li>
-<li class="footnote" id="fn-ref3"><p>Ullamcorper Etiam Fringilla (test) <a class="footnote-backref" rev="footnote" href="#fn-ref-ref3">&#8617;</a> <a class="footnote-backref" rev="footnote" href="#fn-ref-ref3__2">&#8617;</a></p></li>
-<li class="footnote" id="fn-ref4"><p>Ref 4 <a class="footnote-backref" rev="footnote" href="#fn-ref-ref4">&#8617;</a></p></li></ol></div>
+consectetur et. Maecenas faucibus mollis interdum. Maecenas faucibus mollis interdum.&nbsp;<a class="footnote-backref" rev="footnote" href="#fn-ref-ref2">&#8617;</a></p></li>
+<li class="footnote" id="fn-ref3"><p>Ullamcorper Etiam Fringilla (test)&nbsp;<a class="footnote-backref" rev="footnote" href="#fn-ref-ref3">&#8617;</a>&nbsp;<a class="footnote-backref" rev="footnote" href="#fn-ref-ref3__2">&#8617;</a></p></li>
+<li class="footnote" id="fn-ref4"><p>Ref 4&nbsp;<a class="footnote-backref" rev="footnote" href="#fn-ref-ref4">&#8617;</a></p></li></ol></div>

--- a/tests/Functional/data/regular.html
+++ b/tests/Functional/data/regular.html
@@ -8,7 +8,7 @@ nisi erat porttitor ligula, eget lacinia odio<a class="footnote-ref" id="fn-ref-
 Cras mattis consectetur purus sit amet fermentum. Fusce dapibus, tellus ac cursus
 commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
 Integer posuere erat a ante venenatis dapibus posuere velit aliquet.</p>
-<div class="footnotes"><hr /><ol><li class="footnote" id="fn-ref"><p>Risus Euismod Pharetra <a class="footnote-backref" rev="footnote" href="#fn-ref-ref">&#8617;</a></p></li>
+<div class="footnotes"><hr /><ol><li class="footnote" id="fn-ref"><p>Risus Euismod Pharetra&nbsp;<a class="footnote-backref" rev="footnote" href="#fn-ref-ref">&#8617;</a></p></li>
 <li class="footnote" id="fn-ref2"><p>Etiam porta sem malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl
-consectetur et. Maecenas faucibus mollis interdum. Maecenas faucibus mollis interdum. <a class="footnote-backref" rev="footnote" href="#fn-ref-ref2">&#8617;</a></p></li>
-<li class="footnote" id="fn-ref3"><p>Ullamcorper Etiam Fringilla (test) <a class="footnote-backref" rev="footnote" href="#fn-ref-ref3">&#8617;</a></p></li></ol></div>
+consectetur et. Maecenas faucibus mollis interdum. Maecenas faucibus mollis interdum.&nbsp;<a class="footnote-backref" rev="footnote" href="#fn-ref-ref2">&#8617;</a></p></li>
+<li class="footnote" id="fn-ref3"><p>Ullamcorper Etiam Fringilla (test)&nbsp;<a class="footnote-backref" rev="footnote" href="#fn-ref-ref3">&#8617;</a></p></li></ol></div>

--- a/tests/Functional/data/with-link-anonymous.html
+++ b/tests/Functional/data/with-link-anonymous.html
@@ -1,2 +1,2 @@
 <p>Ils peuvent y avoir <a href="https://www.gov.uk">gratuitement accès</a> pour une audience devant un tribunal.<a class="footnote-ref" id="fn-ref-super-note" href="#fn-super-note"><sup>1</sup></a></p>
-<div class="footnotes"><hr /><ol><li class="footnote" id="fn-super-note"><p>Super note <a class="footnote-backref" rev="footnote" href="#fn-ref-super-note">&#8617;</a></p></li></ol></div>
+<div class="footnotes"><hr /><ol><li class="footnote" id="fn-super-note"><p>Super note&nbsp;<a class="footnote-backref" rev="footnote" href="#fn-ref-super-note">&#8617;</a></p></li></ol></div>

--- a/tests/Functional/data/with-link.html
+++ b/tests/Functional/data/with-link.html
@@ -1,2 +1,2 @@
 <p>Ils peuvent y avoir <a href="https://www.gov.uk">gratuitement accès</a> pour une audience devant un tribunal.<a class="footnote-ref" id="fn-ref-matei" href="#fn-matei"><sup>1</sup></a></p>
-<div class="footnotes"><hr /><ol><li class="footnote" id="fn-matei"><p>Information <strong>communiquée à <em>Prison Insider</em></strong> par Matei Clej, interprète judiciaire, le 18 avril 2019. <a class="footnote-backref" rev="footnote" href="#fn-ref-matei">&#8617;</a></p></li></ol></div>
+<div class="footnotes"><hr /><ol><li class="footnote" id="fn-matei"><p>Information <strong>communiquée à <em>Prison Insider</em></strong> par Matei Clej, interprète judiciaire, le 18 avril 2019.&nbsp;<a class="footnote-backref" rev="footnote" href="#fn-ref-matei">&#8617;</a></p></li></ol></div>


### PR DESCRIPTION
Add a `&nbsp;` instead of a simple space ` ` before back-refs to avoid *orphan* back-refs. (See last footnote.)

This behavior matches michelf/php-markdown's footnotes.

### Behavior of `commonmark-ext-footnotes` before change

<img width="510" alt="Screenshot 2020-03-06 09 46 30" src="https://user-images.githubusercontent.com/1243210/76067362-85531c80-5f8f-11ea-85cd-fffc3c310bb6.png">

### Behavior of `commonmark-ext-footnotes` after change

<img width="510" alt="Screenshot 2020-03-06 09 45 30" src="https://user-images.githubusercontent.com/1243210/76067373-87b57680-5f8f-11ea-8f0e-0a37522ebe74.png">

### Behavior of `michelf/php-markdown`

<img width="510" alt="Screenshot 2020-03-06 09 46 51" src="https://user-images.githubusercontent.com/1243210/76067379-8ab06700-5f8f-11ea-9b22-a16ec8372a84.png">